### PR TITLE
Refactor: Process potential events from transaction output

### DIFF
--- a/channel/subscribe.go
+++ b/channel/subscribe.go
@@ -40,8 +40,8 @@ func (s *AdjEventSub) Next() pchannel.AdjudicatorEvent {
 		case *event.DisputedEvent:
 			log.Println("DisputedEvent received")
 			dispEvent := pchannel.AdjudicatorEventBase{
-				VersionV: e.Version(),
-				IDV:      e.ID(),
+				VersionV: e.GetVersion(),
+				IDV:      e.GetID(),
 				TimeoutV: event.MakeTimeout(*s.challengeDuration),
 			}
 			ddn := &pchannel.RegisteredEvent{AdjudicatorEventBase: dispEvent, State: nil, Sigs: nil}
@@ -52,8 +52,8 @@ func (s *AdjEventSub) Next() pchannel.AdjudicatorEvent {
 
 			log.Println("CloseEvent received")
 			conclEvent := pchannel.AdjudicatorEventBase{
-				VersionV: e.Version(),
-				IDV:      e.ID(),
+				VersionV: e.GetVersion(),
+				IDV:      e.GetID(),
 				TimeoutV: event.MakeTimeout(*s.challengeDuration),
 			}
 			ccn := &pchannel.ConcludedEvent{AdjudicatorEventBase: conclEvent}

--- a/client/client.go
+++ b/client/client.go
@@ -1,3 +1,17 @@
+// Copyright 2024 PolyCrypt GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package client
 
 import (
@@ -43,9 +57,14 @@ func (c *Client) Open(ctx context.Context, perunAddr xdr.ScAddress, params *pcha
 		return errors.New("error while invoking and processing host function: open")
 	}
 
-	_, err = event.DecodeEventsPerun(txMeta)
+	evs, err := event.DecodeEventsPerun(txMeta)
 	if err != nil {
 		return errors.New("error while decoding events")
+	}
+
+	err = event.AssertOpenEvent(evs)
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -83,9 +102,28 @@ func (c *Client) Fund(ctx context.Context, perunAddr xdr.ScAddress, assetAddr xd
 		return errors.New("error while invoking and processing host function: fund")
 	}
 
-	_, err = event.DecodeEventsPerun(txMeta)
+	evs, err := event.DecodeEventsPerun(txMeta)
 	if err != nil {
-		return errors.New("error while decoding events")
+		return err
+	}
+
+	err = event.AssertFundedEvent(evs)
+
+	if err == event.ErrNoFundEvent {
+		chanFunded, err := c.GetChannelInfo(ctx, perunAddr, chanID)
+		if err != nil {
+			return err
+		}
+		if chanFunded.Control.FundedA || chanFunded.Control.FundedB {
+			return nil
+		} else if chanFunded.Control.FundedA != chanFunded.Control.FundedB {
+			return nil
+		} else {
+			return errors.New("no funding happened after calling fund")
+		}
+
+	} else if err != nil {
+		return event.ErrNoFundEvent
 	}
 
 	return nil
@@ -103,12 +141,23 @@ func (c *Client) Close(ctx context.Context, perunAddr xdr.ScAddress, state *pcha
 		return errors.New("error while invoking and processing host function: close")
 	}
 
-	_, err = event.DecodeEventsPerun(txMeta)
+	evs, err := event.DecodeEventsPerun(txMeta)
 	if err != nil {
 		return errors.New("error while decoding events")
 	}
 
-	return nil
+	err = event.AssertCloseEvent(evs)
+	if err == event.ErrNoCloseEvent {
+		chanInfo, err := c.GetChannelInfo(ctx, perunAddr, state.ID)
+		if err != nil {
+			return errors.New("could not get channel info")
+		}
+		if chanInfo.Control.Closed {
+			return nil
+		}
+	}
+
+	return event.ErrNoCloseEvent
 }
 
 func (c *Client) ForceClose(ctx context.Context, perunAddr xdr.ScAddress, chanId pchannel.ID) error {
@@ -122,10 +171,27 @@ func (c *Client) ForceClose(ctx context.Context, perunAddr xdr.ScAddress, chanId
 	if err != nil {
 		return errors.New("error while invoking and processing host function")
 	}
-	_, err = event.DecodeEventsPerun(txMeta)
+	evs, err := event.DecodeEventsPerun(txMeta)
 	if err != nil {
 		return errors.New("error while decoding events")
 	}
+
+	err = event.AssertForceCloseEvent(evs)
+	if err == event.ErrNoForceCloseEvent {
+		chanInfo, err := c.GetChannelInfo(ctx, perunAddr, chanId)
+		if err != nil {
+			return errors.New("could not retrieve channel info")
+		}
+		if !chanInfo.Control.Disputed {
+			return errors.New("force close of a state that is not disputed")
+		}
+
+		if chanInfo.Control.Closed {
+			return errors.New("force close of a channel that is closed already")
+		}
+
+	}
+
 	return nil
 }
 
@@ -138,42 +204,62 @@ func (c *Client) Dispute(ctx context.Context, perunAddr xdr.ScAddress, state *pc
 	if err != nil {
 		return errors.New("error while invoking and processing host function: dispute")
 	}
-	_, err = event.DecodeEventsPerun(txMeta)
+	evs, err := event.DecodeEventsPerun(txMeta)
+
 	if err != nil {
 		return errors.New("error while decoding events")
 	}
+
+	err = event.AssertDisputeEvent(evs)
+	if err == event.ErrNoDisputeEvent {
+		chanInfo, err := c.GetChannelInfo(ctx, perunAddr, state.ID)
+		if err != nil {
+			return errors.New("could not retrieve channel info")
+		}
+		if chanInfo.Control.Disputed || chanInfo.Control.Closed {
+			return nil
+		}
+	} else {
+		return err
+	}
+
 	return nil
 }
-
 func (c *Client) Withdraw(ctx context.Context, perunAddr xdr.ScAddress, req pchannel.AdjudicatorReq) error {
-	chanIDStellar := req.Tx.State.ID
-	partyIdx := req.Idx
-
-	var withdrawerIdx bool
-
-	if partyIdx == 0 {
-		withdrawerIdx = false
-	} else if partyIdx == 1 {
-		withdrawerIdx = true
-	} else {
+	chanID, partyIdx := req.Tx.State.ID, req.Idx
+	withdrawerIdx := partyIdx == 1
+	if partyIdx > 1 {
 		return errors.New("invalid party index for withdrawal")
 	}
 
-	withdrawTxArgs, err := buildChanIdxTxArgs(chanIDStellar, withdrawerIdx)
+	withdrawTxArgs, err := buildChanIdxTxArgs(chanID, withdrawerIdx)
 	if err != nil {
-		return errors.New("error while building fund tx")
+		return errors.New("error building fund tx")
 	}
 	txMeta, err := c.InvokeAndProcessHostFunction("withdraw", withdrawTxArgs, perunAddr)
 	if err != nil {
-		return errors.New("error while invoking and processing host function: withdraw")
+		return errors.New("error in host function: withdraw")
 	}
 
-	_, err = event.DecodeEventsPerun(txMeta)
+	evs, err := event.DecodeEventsPerun(txMeta)
 	if err != nil {
-		return errors.New("error while decoding events")
+		return event.ErrEventDecode
 	}
 
-	return nil
+	err = event.AssertWithdrawEvent(evs)
+	if err != event.ErrNoWithdrawEvent {
+		return err
+	}
+
+	chanInfo, err := c.GetChannelInfo(ctx, perunAddr, chanID)
+	if err != nil {
+		return err
+	}
+	if (withdrawerIdx && chanInfo.Control.WithdrawnB) || (!withdrawerIdx && chanInfo.Control.WithdrawnA) {
+		return nil
+	}
+
+	return event.ErrNoWithdrawEvent
 }
 
 func (c *Client) GetChannelInfo(ctx context.Context, perunAddr xdr.ScAddress, chanId pchannel.ID) (wire.Channel, error) {

--- a/client/client.go
+++ b/client/client.go
@@ -31,6 +31,8 @@ import (
 
 var _ StellarClient = (*Client)(nil)
 
+var ErrCouldNotDecodeTxMeta = errors.New("could not decode tx output")
+
 type Client struct {
 	hzClient  *horizonclient.Client
 	keyHolder keyHolder
@@ -59,7 +61,7 @@ func (c *Client) Open(ctx context.Context, perunAddr xdr.ScAddress, params *pcha
 
 	evs, err := event.DecodeEventsPerun(txMeta)
 	if err != nil {
-		return errors.New("error while decoding events")
+		return err
 	}
 
 	err = event.AssertOpenEvent(evs)
@@ -84,7 +86,7 @@ func (c *Client) Abort(ctx context.Context, perunAddr xdr.ScAddress, state *pcha
 
 	_, err = event.DecodeEventsPerun(txMeta)
 	if err != nil {
-		return errors.New("error while decoding events")
+		return err
 	}
 
 	return nil
@@ -99,7 +101,7 @@ func (c *Client) Fund(ctx context.Context, perunAddr xdr.ScAddress, assetAddr xd
 
 	txMeta, err := c.InvokeAndProcessHostFunction("fund", fundTxArgs, perunAddr)
 	if err != nil {
-		return errors.New("error while invoking and processing host function: fund")
+		return err
 	}
 
 	evs, err := event.DecodeEventsPerun(txMeta)
@@ -143,7 +145,7 @@ func (c *Client) Close(ctx context.Context, perunAddr xdr.ScAddress, state *pcha
 
 	evs, err := event.DecodeEventsPerun(txMeta)
 	if err != nil {
-		return errors.New("error while decoding events")
+		return err
 	}
 
 	err = event.AssertCloseEvent(evs)
@@ -173,7 +175,7 @@ func (c *Client) ForceClose(ctx context.Context, perunAddr xdr.ScAddress, chanId
 	}
 	evs, err := event.DecodeEventsPerun(txMeta)
 	if err != nil {
-		return errors.New("error while decoding events")
+		return err
 	}
 
 	err = event.AssertForceCloseEvent(evs)
@@ -207,7 +209,7 @@ func (c *Client) Dispute(ctx context.Context, perunAddr xdr.ScAddress, state *pc
 	evs, err := event.DecodeEventsPerun(txMeta)
 
 	if err != nil {
-		return errors.New("error while decoding events")
+		return err
 	}
 
 	err = event.AssertDisputeEvent(evs)
@@ -243,7 +245,7 @@ func (c *Client) Withdraw(ctx context.Context, perunAddr xdr.ScAddress, req pcha
 
 	evs, err := event.DecodeEventsPerun(txMeta)
 	if err != nil {
-		return event.ErrEventDecode
+		return err
 	}
 
 	err = event.AssertWithdrawEvent(evs)

--- a/client/transaction.go
+++ b/client/transaction.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"errors"
 	"github.com/creachadair/jrpc2"
 	"github.com/creachadair/jrpc2/jhttp"
 	"github.com/stellar/go/clients/horizonclient"
@@ -75,7 +74,7 @@ func (c *Client) InvokeAndProcessHostFunction(fname string, callTxArgs xdr.ScVec
 	// Decode transaction metadata
 	txMeta, err := DecodeTxMeta(tx)
 	if err != nil {
-		return xdr.TransactionMeta{}, errors.New("error while decoding tx meta")
+		return xdr.TransactionMeta{}, ErrCouldNotDecodeTxMeta
 	}
 	_ = txMeta.V3.SorobanMeta.ReturnValue
 

--- a/event/event.go
+++ b/event/event.go
@@ -54,7 +54,6 @@ var (
 	ErrNotStellarPerunContract = errors.New("event was not from a Perun payment channel contract")
 	ErrEventUnsupported        = errors.New("this type of event is unsupported")
 	ErrEventIntegrity          = errors.New("contract ID does not match payment channel + passphrase")
-	ErrEventDecode             = errors.New("error while decoding events")
 	ErrNoFundEvent             = errors.New("fund event not found")
 	ErrNoCloseEvent            = errors.New("close event not found")
 	ErrNoWithdrawEvent         = errors.New("withdraw event not found")
@@ -73,38 +72,37 @@ type (
 	}
 
 	OpenEvent struct {
-		channel   wire.Channel
-		eventType EventType
-		idv       pchannel.ID
-		versionV  Version
+		channel wire.Channel
+		// eventType EventType
+		idv      pchannel.ID
+		versionV Version
 	}
 	FundEvent struct {
-		channel   wire.Channel
-		eventType EventType
-		idv       pchannel.ID
-		versionV  Version
+		channel wire.Channel
+		// eventType EventType
+		idv      pchannel.ID
+		versionV Version
 	}
 
 	CloseEvent struct {
-		channel   wire.Channel
-		eventType EventType
-		idv       pchannel.ID
-		versionV  Version
+		channel wire.Channel
+		// eventType EventType
+		idv      pchannel.ID
+		versionV Version
 	}
 
 	WithdrawnEvent struct {
-		channel   wire.Channel
-		eventType EventType
-		idv       pchannel.ID
-		versionV  Version
-		// Timestamp uint64
+		channel wire.Channel
+		// eventType EventType
+		idv      pchannel.ID
+		versionV Version
 	}
 
 	DisputedEvent struct {
-		channel   wire.Channel
-		eventType EventType
-		idv       pchannel.ID
-		versionV  Version
+		channel wire.Channel
+		// eventType EventType
+		idv      pchannel.ID
+		versionV Version
 	}
 )
 

--- a/event/event.go
+++ b/event/event.go
@@ -32,8 +32,9 @@ const (
 	EventTypeClosed                  // channel closed -> withdrawing enabled
 	EventTypeWithdrawing             // participant/s withdrawing
 	EventTypeWithdrawn               // participants have withdrawn
-	EventTypeForceClosed             // participant has force closed the channel
+	EventTypeForceClose              // participant has force closed the channel
 	EventTypeDisputed                // participant has disputed the channel
+	EventTypeError                   // inconsistent event
 )
 
 const AssertPerunSymbol = "perun"
@@ -46,51 +47,64 @@ var (
 		xdr.ScSymbol("closed"):   EventTypeClosed,
 		xdr.ScSymbol("withdraw"): EventTypeWithdrawing,
 		xdr.ScSymbol("pay_c"):    EventTypeWithdrawn,
-		xdr.ScSymbol("f_closed"): EventTypeForceClosed,
+		xdr.ScSymbol("f_closed"): EventTypeForceClose,
 		xdr.ScSymbol("dispute"):  EventTypeDisputed,
 	}
 
 	ErrNotStellarPerunContract = errors.New("event was not from a Perun payment channel contract")
 	ErrEventUnsupported        = errors.New("this type of event is unsupported")
 	ErrEventIntegrity          = errors.New("contract ID does not match payment channel + passphrase")
+	ErrEventDecode             = errors.New("error while decoding events")
+	ErrNoFundEvent             = errors.New("fund event not found")
+	ErrNoCloseEvent            = errors.New("close event not found")
+	ErrNoWithdrawEvent         = errors.New("withdraw event not found")
+	ErrNoDisputeEvent          = errors.New("dispute event not found")
+	ErrNoForceCloseEvent       = errors.New("force close event not found")
 )
 
 type controlsState map[string]bool
 
 type (
 	PerunEvent interface {
-		ID() pchannel.ID
-		Version() Version
+		GetID() pchannel.ID
+		GetChannel() wire.Channel
+		GetVersion() Version
+		GetType() (EventType, error)
 	}
 
 	OpenEvent struct {
-		Channel  wire.Channel
-		IDV      pchannel.ID
-		VersionV Version
+		channel   wire.Channel
+		eventType EventType
+		idv       pchannel.ID
+		versionV  Version
 	}
 	FundEvent struct {
-		Channel  wire.Channel
-		IDV      pchannel.ID
-		VersionV Version
+		channel   wire.Channel
+		eventType EventType
+		idv       pchannel.ID
+		versionV  Version
 	}
 
 	CloseEvent struct {
-		Channel  wire.Channel
-		IDV      pchannel.ID
-		VersionV Version
+		channel   wire.Channel
+		eventType EventType
+		idv       pchannel.ID
+		versionV  Version
 	}
 
 	WithdrawnEvent struct {
-		Channel   wire.Channel
-		IDV       pchannel.ID
-		VersionV  Version
-		Timestamp uint64
+		channel   wire.Channel
+		eventType EventType
+		idv       pchannel.ID
+		versionV  Version
+		// Timestamp uint64
 	}
 
 	DisputedEvent struct {
-		Channel  wire.Channel
-		IDV      pchannel.ID
-		VersionV Version
+		channel   wire.Channel
+		eventType EventType
+		idv       pchannel.ID
+		versionV  Version
 	}
 )
 
@@ -104,50 +118,93 @@ func (e *StellarEvent) GetType() EventType {
 }
 
 func (e *OpenEvent) GetChannel() wire.Channel {
-	return e.Channel
+	return e.channel
+}
+func (e *OpenEvent) GetType() (EventType, error) {
+	return EventTypeOpen, nil
 }
 
-func (e *OpenEvent) ID() pchannel.ID {
-	return e.IDV
+func (e *OpenEvent) GetID() pchannel.ID {
+	return e.idv
 }
-func (e *OpenEvent) Version() Version {
-	return e.VersionV
+func (e *OpenEvent) GetVersion() Version {
+	return e.versionV
 }
 
 func (e *WithdrawnEvent) GetChannel() wire.Channel {
-	return e.Channel
+	return e.channel
 }
 
-func (e *WithdrawnEvent) ID() pchannel.ID {
-	return e.IDV
+func (e *WithdrawnEvent) GetType() (EventType, error) {
+	withdrawnA := e.channel.Control.WithdrawnA
+	withdrawnB := e.channel.Control.WithdrawnB
+
+	if withdrawnA && withdrawnB {
+		return EventTypeWithdrawn, nil
+	} else if withdrawnA != withdrawnB {
+		return EventTypeWithdrawing, nil
+	}
+	return EventTypeError, errors.New("withdraw event has no consistent type: not withdrawn")
 }
-func (e *WithdrawnEvent) Version() Version {
-	return e.VersionV
+
+func (e *WithdrawnEvent) GetID() pchannel.ID {
+	return e.idv
+}
+func (e *WithdrawnEvent) GetVersion() Version {
+	return e.versionV
 }
 
 func (e *CloseEvent) GetChannel() wire.Channel {
-	return e.Channel
+	return e.channel
 }
 
-func (e *CloseEvent) ID() pchannel.ID {
-	return e.IDV
-}
-func (e *CloseEvent) Version() Version {
-	return e.VersionV
+func (e *CloseEvent) GetType() (EventType, error) {
+	return EventTypeClosed, nil
 }
 
-func (e *FundEvent) ID() pchannel.ID {
-	return e.IDV
+func (e *CloseEvent) GetID() pchannel.ID {
+	return e.idv
 }
-func (e *FundEvent) Version() Version {
-	return e.VersionV
+func (e *CloseEvent) GetVersion() Version {
+	return e.versionV
+}
+func (e *FundEvent) GetChannel() wire.Channel {
+	return e.channel
 }
 
-func (e *DisputedEvent) ID() pchannel.ID {
-	return e.IDV
+func (e *FundEvent) GetType() (EventType, error) {
+	fundedA := e.channel.Control.FundedA
+	fundedB := e.channel.Control.FundedB
+
+	if fundedA && fundedB {
+		return EventTypeFundedChannel, nil
+	} else if fundedA != fundedB {
+		return EventTypeFundChannel, nil
+	}
+	return EventTypeError, errors.New("funding event has no consistent type: not funded")
 }
-func (e *DisputedEvent) Version() Version {
-	return e.VersionV
+
+func (e *FundEvent) GetID() pchannel.ID {
+	return e.idv
+}
+func (e *FundEvent) GetVersion() Version {
+	return e.versionV
+}
+
+func (e *DisputedEvent) GetID() pchannel.ID {
+	return e.idv
+}
+
+func (e *DisputedEvent) GetChannel() wire.Channel {
+	return e.channel
+}
+
+func (e *DisputedEvent) GetVersion() Version {
+	return e.versionV
+}
+
+func (e *DisputedEvent) GetType() (EventType, error) {
+	return EventTypeDisputed, nil
 }
 
 func DecodeEventsPerun(txMeta xdr.TransactionMeta) ([]PerunEvent, error) {
@@ -160,7 +217,7 @@ func DecodeEventsPerun(txMeta xdr.TransactionMeta) ([]PerunEvent, error) {
 		topics := ev.Body.V0.Topics
 
 		if len(topics) < 2 {
-			return []PerunEvent{}, ErrNotStellarPerunContract
+			return nil, ErrNotStellarPerunContract
 		}
 		perunString, ok := topics[0].GetSym()
 
@@ -169,19 +226,19 @@ func DecodeEventsPerun(txMeta xdr.TransactionMeta) ([]PerunEvent, error) {
 		}
 
 		if perunString != AssertPerunSymbol {
-			return []PerunEvent{}, ErrNotStellarPerunContract
+			return nil, ErrNotStellarPerunContract
 		}
 		if !ok {
-			return []PerunEvent{}, ErrNotStellarPerunContract
+			return nil, ErrNotStellarPerunContract
 		}
 
 		fn, ok := topics[1].GetSym()
 		if !ok {
-			return []PerunEvent{}, ErrNotStellarPerunContract
+			return nil, ErrNotStellarPerunContract
 		}
 
 		if eventType, found := STELLAR_PERUN_CHANNEL_CONTRACT_TOPICS[fn]; !found {
-			return []PerunEvent{}, ErrNotStellarPerunContract
+			return nil, ErrNotStellarPerunContract
 		} else {
 			sev.Type = eventType
 		}
@@ -191,7 +248,7 @@ func DecodeEventsPerun(txMeta xdr.TransactionMeta) ([]PerunEvent, error) {
 
 			openEventchanStellar, err := GetChannelFromEvents(ev.Body.V0.Data)
 			if err != nil {
-				return []PerunEvent{}, err
+				return nil, err
 			}
 
 			controlsOpen := initControlState(openEventchanStellar.Control)
@@ -202,7 +259,7 @@ func DecodeEventsPerun(txMeta xdr.TransactionMeta) ([]PerunEvent, error) {
 			}
 
 			openEvent := OpenEvent{
-				Channel: openEventchanStellar,
+				channel: openEventchanStellar,
 			}
 
 			evs = append(evs, &openEvent)
@@ -210,32 +267,43 @@ func DecodeEventsPerun(txMeta xdr.TransactionMeta) ([]PerunEvent, error) {
 		case EventTypeFundChannel:
 			fundEventchanStellar, _, err := GetChannelBoolFromEvents(ev.Body.V0.Data)
 			if err != nil {
-				return []PerunEvent{}, err
+				return nil, err
 			}
 
 			fundEvent := FundEvent{
-				Channel: fundEventchanStellar,
+				channel: fundEventchanStellar,
 			}
 			evs = append(evs, &fundEvent)
 		case EventTypeClosed:
 			closedEventchanStellar, err := GetChannelFromEvents(ev.Body.V0.Data)
 			if err != nil {
-				return []PerunEvent{}, err
+				return nil, err
 			}
 
 			closeEvent := CloseEvent{
-				Channel: closedEventchanStellar,
+				channel: closedEventchanStellar,
 			}
 			evs = append(evs, &closeEvent)
 		case EventTypeWithdrawn:
 			withdrawnEventchanStellar, err := GetChannelFromEvents(ev.Body.V0.Data)
 			if err != nil {
-				return []PerunEvent{}, err
+				return nil, err
 			}
 			withdrawnEvent := WithdrawnEvent{
-				Channel: withdrawnEventchanStellar,
+				channel: withdrawnEventchanStellar,
 			}
 			evs = append(evs, &withdrawnEvent)
+
+		case EventTypeDisputed:
+			disputedEventchanStellar, err := GetChannelFromEvents(ev.Body.V0.Data)
+			if err != nil {
+				return nil, err
+			}
+			disputedEvent := DisputedEvent{
+				channel: disputedEventchanStellar,
+			}
+			evs = append(evs, &disputedEvent)
+
 		}
 
 	}
@@ -294,5 +362,116 @@ func checkOpen(cState controlsState) error {
 			return errors.New(key + " is not false")
 		}
 	}
+	return nil
+}
+
+func AssertOpenEvent(perunEvents []PerunEvent) error {
+
+	if len(perunEvents) == 0 {
+		return errors.New("no open event found after opening a channel")
+	}
+
+	for _, ev := range perunEvents {
+		eventType, err := ev.GetType()
+		if err != nil {
+			return errors.New("could not retrieve type from event")
+		}
+		switch eventType {
+		case EventTypeOpen:
+			return nil
+		case EventTypeDisputed:
+			return errors.New("disputed already before channel open")
+		case EventTypeFundChannel, EventTypeFundedChannel:
+			if ev.GetChannel().Control.FundedA || ev.GetChannel().Control.FundedB {
+				return nil
+			} else {
+				return errors.New("funded channel not open yet")
+			}
+		}
+	}
+	return errors.New("no event found after opening a channel")
+}
+
+func AssertFundedEvent(perunEvents []PerunEvent) error {
+	for _, ev := range perunEvents {
+		eventType, err := ev.GetType()
+		if err != nil {
+			return err
+		}
+		switch eventType {
+		case EventTypeFundChannel, EventTypeFundedChannel:
+			return nil
+		default:
+			return ErrNoFundEvent
+		}
+	}
+
+	return nil
+}
+
+func AssertCloseEvent(perunEvents []PerunEvent) error {
+	for _, ev := range perunEvents {
+		eventType, err := ev.GetType()
+		if err != nil {
+			return err
+		}
+		switch eventType {
+		case EventTypeClosed:
+			return nil
+		default:
+			return ErrNoCloseEvent
+		}
+	}
+
+	return nil
+}
+
+func AssertWithdrawEvent(perunEvents []PerunEvent) error {
+	for _, ev := range perunEvents {
+		eventType, err := ev.GetType()
+		if err != nil {
+			return err
+		}
+		switch eventType {
+		case EventTypeWithdrawing, EventTypeWithdrawn:
+			return nil
+		default:
+			return ErrNoWithdrawEvent
+		}
+	}
+
+	return nil
+}
+func AssertForceCloseEvent(perunEvents []PerunEvent) error {
+	for _, ev := range perunEvents {
+		eventType, err := ev.GetType()
+		if err != nil {
+			return err
+		}
+		switch eventType {
+		case EventTypeForceClose:
+			return nil
+		default:
+			return ErrNoForceCloseEvent
+		}
+	}
+
+	return nil
+}
+
+func AssertDisputeEvent(perunEvents []PerunEvent) error {
+	for _, ev := range perunEvents {
+		eventType, err := ev.GetType()
+		if err != nil {
+			return err
+		}
+		switch eventType {
+		case EventTypeDisputed:
+			return nil
+		default:
+			return ErrNoDisputeEvent
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
This PR improves event handling after reading out the transaction output in the client package.
This improves security and handles edge cases in which some contract functions are called multiple times. 

Contract calls to not trigger events if the call has been made before. For instance, when a ```close``` has been made, a subsequent ```close``` call will result in an error and will not emit a contract event. This PR handles such cases gracefully.