### PR TITLE
Add Sender interface

### DIFF
--- a/channel/test/token.go
+++ b/channel/test/token.go
@@ -109,7 +109,7 @@ func InitTokenContract(kp *keypair.Full, contractIDAddress xdr.ScAddress) error 
 
 	txMeta, err := cb.InvokeSignedTx("initialize", initArgs, contractIDAddress)
 	if err != nil {
-		return errors.New("error while invoking and processing host function: abort_funding")
+		return errors.New("error while invoking and processing host function: initialize" + err.Error())
 	}
 
 	_, err = event.DecodeEventsPerun(txMeta)

--- a/client/contractbackend.go
+++ b/client/contractbackend.go
@@ -16,7 +16,7 @@ import (
 const stellarDefaultChainId = 1
 
 type Sender interface {
-	signSendTx(txnbuild.Transaction) (xdr.TransactionMeta, error)
+	SignSendTx(txnbuild.Transaction) (xdr.TransactionMeta, error)
 }
 
 type ContractBackend struct {
@@ -188,7 +188,7 @@ func (c *ContractBackend) InvokeSignedTxNew(fname string, callTxArgs xdr.ScVec, 
 		return xdr.TransactionMeta{}, err
 	}
 	// txSigned, err := c.tr.createSignedTxFromParams(txParams)
-	txMeta, err := c.tr.sender.signSendTx(*txUnsigned)
+	txMeta, err := c.tr.sender.SignSendTx(*txUnsigned)
 
 	if err != nil {
 		return xdr.TransactionMeta{}, err

--- a/client/transactor.go
+++ b/client/transactor.go
@@ -1,8 +1,10 @@
 package client
 
 import (
+	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/go/txnbuild"
+	"github.com/stellar/go/xdr"
 )
 
 func CreateSignedTransactionWithParams(signers []*keypair.Full, txParams txnbuild.TransactionParams,
@@ -19,4 +21,38 @@ func CreateSignedTransactionWithParams(signers []*keypair.Full, txParams txnbuil
 		}
 	}
 	return tx, nil
+}
+
+type TxSender struct {
+	kp       *keypair.Full
+	hzClient *horizonclient.Client
+}
+
+func NewSender(kp *keypair.Full) Sender {
+	return &TxSender{kp: kp}
+
+}
+
+func (s *TxSender) signSendTx(txUnsigned txnbuild.Transaction) (xdr.TransactionMeta, error) {
+	tx, err := txUnsigned.Sign(NETWORK_PASSPHRASE, s.kp)
+	if err != nil {
+		return xdr.TransactionMeta{}, err
+
+	}
+
+	txSent, err := s.hzClient.SubmitTransaction(tx)
+	if err != nil {
+		return xdr.TransactionMeta{}, err
+	}
+	txMeta, err := DecodeTxMeta(txSent)
+	if err != nil {
+		return xdr.TransactionMeta{}, ErrCouldNotDecodeTxMeta
+	}
+	_ = txMeta.V3.SorobanMeta.ReturnValue
+	return txMeta, nil
+
+}
+
+func (s *TxSender) SetHzClient(hzClient *horizonclient.Client) {
+	s.hzClient = hzClient
 }

--- a/client/transactor.go
+++ b/client/transactor.go
@@ -33,7 +33,7 @@ func NewSender(kp *keypair.Full) Sender {
 
 }
 
-func (s *TxSender) signSendTx(txUnsigned txnbuild.Transaction) (xdr.TransactionMeta, error) {
+func (s *TxSender) SignSendTx(txUnsigned txnbuild.Transaction) (xdr.TransactionMeta, error) {
 	tx, err := txUnsigned.Sign(NETWORK_PASSPHRASE, s.kp)
 	if err != nil {
 		return xdr.TransactionMeta{}, err


### PR DESCRIPTION
This allows to use custom Sender implementations when signing L1 transactions is external to the Stellar backend. 

In this library, however, we use the TxSender object, which is able to use its keypair to sign transactions.